### PR TITLE
Fix Bluebird warning

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -132,6 +132,7 @@ Cursor.prototype._fetch = function() {
     self.connection._continue(self.token, resolve, reject);
   }).then(function(response) {
     self._push(response);
+    return null;
   }).error(function(error) {
     self._fetching = false;
     self._canFetch = false;


### PR DESCRIPTION
Bluebird complains here because nothing is returned on the `then` statement of the promise.